### PR TITLE
Added tests for rendering the same Noise on different Level of detail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ ndarray = "0.15"
 bevy = { version = "0.8.1", features = ["dynamic"] }
 bevy_egui = "0.16.0"
 #bevy_screen_diags = "0.4.0"
-noise = "0.7.0"
+noise = "0.8.2"
 rand = "0.8.3"
+rand_chacha = "0.3.1"
 
 [profile.dev]
 opt-level = 3

--- a/src/implementation/density_caching.rs
+++ b/src/implementation/density_caching.rs
@@ -69,7 +69,8 @@ where
         }
         let subs = self.block_subdivisions;
         let face_size = (subs + 1) * (subs + 1);
-        self.regular_cache_extended.resize(6 * face_size, D::default());
+        self.regular_cache_extended
+            .resize(6 * face_size, D::default());
         // -x
         for y in 0..=subs {
             for z in 0..=subs {
@@ -205,42 +206,44 @@ where
         let z = voxel_index.z;
         let subs = self.block_subdivisions;
         let face_size = (subs + 1) * (subs + 1);
-        if x == -1 {
-            debug_assert!(y >= 0 && y <= subs as isize && z >= 0 && z <= subs as isize);
-            let index = 0 * face_size + (subs + 1) * y as usize + z as usize;
-            return self.regular_cache_extended[index];
-        } else if x == subs as isize + 1 {
-            debug_assert!(y >= 0 && y <= subs as isize && z >= 0 && z <= subs as isize);
-            let index = 1 * face_size + (subs + 1) * y as usize + z as usize;
-            return self.regular_cache_extended[index];
-        } else if y == -1 {
-            debug_assert!(x >= 0 && x <= subs as isize && z >= 0 && z <= subs as isize);
-            let index = 2 * face_size + (subs + 1) * x as usize + z as usize;
-            return self.regular_cache_extended[index];
-        } else if y == subs as isize + 1 {
-            debug_assert!(x >= 0 && x <= subs as isize && z >= 0 && z <= subs as isize);
-            let index = 3 * face_size + (subs + 1) * x as usize + z as usize;
-            return self.regular_cache_extended[index];
-        } else if z == -1 {
-            debug_assert!(x >= 0 && x <= subs as isize && y >= 0 && y <= subs as isize);
-            let index = 4 * face_size + (subs + 1) * x as usize + y as usize;
-            return self.regular_cache_extended[index];
-        } else if z == subs as isize + 1 {
-            debug_assert!(x >= 0 && x <= subs as isize && y >= 0 && y <= subs as isize);
-            let index = 5 * face_size + (subs + 1) * x as usize + y as usize;
-            return self.regular_cache_extended[index];
-        } else {
-            debug_assert!(
-                x >= 0
-                    && x <= subs as isize
-                    && y >= 0
-                    && y <= subs as isize
-                    && z >= 0
-                    && z <= subs as isize
-            );
-            let index = self.regular_block_index(x, y, z);
-            return self.regular_cache[index];
+
+        if 0 < self.regular_cache_extended.len() {
+            if x == -1 {
+                debug_assert!(y >= 0 && y <= subs as isize && z >= 0 && z <= subs as isize);
+                let index = 0 * face_size + (subs + 1) * y as usize + z as usize;
+                return self.regular_cache_extended[index];
+            } else if x == subs as isize + 1 {
+                debug_assert!(y >= 0 && y <= subs as isize && z >= 0 && z <= subs as isize);
+                let index = 1 * face_size + (subs + 1) * y as usize + z as usize;
+                return self.regular_cache_extended[index];
+            } else if y == -1 {
+                debug_assert!(x >= 0 && x <= subs as isize && z >= 0 && z <= subs as isize);
+                let index = 2 * face_size + (subs + 1) * x as usize + z as usize;
+                return self.regular_cache_extended[index];
+            } else if y == subs as isize + 1 {
+                debug_assert!(x >= 0 && x <= subs as isize && z >= 0 && z <= subs as isize);
+                let index = 3 * face_size + (subs + 1) * x as usize + z as usize;
+                return self.regular_cache_extended[index];
+            } else if z == -1 {
+                debug_assert!(x >= 0 && x <= subs as isize && y >= 0 && y <= subs as isize);
+                let index = 4 * face_size + (subs + 1) * x as usize + y as usize;
+                return self.regular_cache_extended[index];
+            } else if z == subs as isize + 1 {
+                debug_assert!(x >= 0 && x <= subs as isize && y >= 0 && y <= subs as isize);
+                let index = 5 * face_size + (subs + 1) * x as usize + y as usize;
+                return self.regular_cache_extended[index];
+            }
         }
+        debug_assert!(
+            x >= 0
+                && x <= subs as isize
+                && y >= 0
+                && y <= subs as isize
+                && z >= 0
+                && z <= subs as isize
+        );
+        let index = self.regular_block_index(x, y, z);
+        return self.regular_cache[index];
     }
 
     fn get_transition_density(&self, index: &HighResolutionVoxelIndex) -> D {

--- a/src/unit_tests/lod_tests.rs
+++ b/src/unit_tests/lod_tests.rs
@@ -70,17 +70,11 @@ impl ScalarField<f32, f32> for &NoiseContainer {
 use crate::structs::Block;
 use crate::extraction::extract_from_field;
 use crate::transition_sides::no_side;
-#[test]
+#[test] /* - For checking if extracting the surface for different resolutions won't crash the app */
 fn extract_field_in_multiple_resolution() {
-    use std::env;	
-    env::set_var("RUST_BACKTRACE", "1");
 	let noise = NoiseContainer::block(64);
-	let mut previous_triangle_count = 0;
 	for resolution in 4..noise.size() {
 		let block = Block::from([0.,0.,0.], noise.size() as f32, resolution);
-		let mesh = extract_from_field(&noise, &block, 0.0, no_side());
-		println!("triangle count: {:?} vs {:?}", previous_triangle_count, mesh.positions.len());
-		assert!(previous_triangle_count < mesh.positions.len());
-		previous_triangle_count = mesh.positions.len();
+		let _mesh = extract_from_field(&noise, &block, 0.0, no_side());
 	}
 }

--- a/src/unit_tests/lod_tests.rs
+++ b/src/unit_tests/lod_tests.rs
@@ -1,0 +1,86 @@
+/**
+ * ######################################################################################
+ * # Tests to see if the same data can be extracted in multiple Level Of Detail safely
+ * ######################################################################################
+ */
+
+/**
+ * Generates noise to check the surface genration against
+ * */
+struct NoiseContainer {
+    pub(crate) buffer: Vec<Vec<Vec<f32>>>,
+}
+
+impl NoiseContainer {
+    fn size(&self) -> usize {
+        self.buffer.len()
+    }
+
+    fn block(dimensions: usize) -> NoiseContainer {
+        let mut buffer = vec![vec![vec![0.; dimensions]; dimensions]; dimensions];
+        let normalizer = dimensions as f64;
+        /* Because the seed for noises are not working, an offset is used to simulate actual randomness */
+        use rand::{Rng, SeedableRng}; 
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis() as u64;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed as u64);
+        let random_offset: Vec<f64> = (0..3).map(|_| rng.gen_range(0.0..1000.0)).collect();
+
+        use noise::HybridMulti;
+        use noise::NoiseFn;
+        use noise::OpenSimplex;
+        let surface_noise = HybridMulti::<OpenSimplex>::new(seed as u32);
+        /* 1..dimensions-1 range is to have an enclosed container */
+        for x in 1..dimensions - 1 {
+            for y in 1..dimensions - 1 {
+                for z in 1..dimensions - 1 {
+                    buffer[x][y][z] = {
+                        let normalized_x = random_offset[0] + x as f64 / normalizer;
+                        let normalized_y = random_offset[1] + y as f64 / normalizer;
+                        let normalized_z = random_offset[2] + z as f64 / normalizer;
+                        surface_noise.get([normalized_x, normalized_y, normalized_z]) as f32
+                    };
+                }
+            }
+        }
+        NoiseContainer { buffer }
+    }
+}
+
+use crate::density::ScalarField;
+impl ScalarField<f32, f32> for &NoiseContainer {
+    fn get_density(&self, x: f32, y: f32, z: f32) -> f32 {
+        let ix = x.round() as i32;
+        let iy = y.round() as i32;
+        let iz = z.round() as i32;
+        if (ix < 0 || ix >= self.size() as i32)
+            || (iy < 0 || iy >= self.size() as i32)
+            || (iz < 0 || iz >= self.size() as i32)
+        {
+            return 0.;
+        }
+
+        self.buffer[ix as usize][iy as usize][iz as usize]
+    }
+}
+
+use crate::structs::Block;
+use crate::extraction::extract_from_field;
+use crate::transition_sides::no_side;
+#[test]
+fn extract_field_in_multiple_resolution() {
+    use std::env;	
+    env::set_var("RUST_BACKTRACE", "1");
+	let noise = NoiseContainer::block(64);
+	let mut previous_triangle_count = 0;
+	for resolution in 4..noise.size() {
+		let block = Block::from([0.,0.,0.], noise.size() as f32, resolution);
+		let mesh = extract_from_field(&noise, &block, 0.0, no_side());
+		println!("triangle count: {:?} vs {:?}", previous_triangle_count, mesh.positions.len());
+		assert!(previous_triangle_count < mesh.positions.len());
+		previous_triangle_count = mesh.positions.len();
+	}
+}

--- a/src/unit_tests/mod.rs
+++ b/src/unit_tests/mod.rs
@@ -2,3 +2,4 @@
 mod test_utils;
 
 mod tests;
+mod lod_tests;


### PR DESCRIPTION
Hi! 
 I thought there was some problem with rendering noisy data on different levels, because seemingly the crashes reacted to setting different resolution; So I wrote a test for that. 
 It turns out this isn't the case, as the crashes are because of incorrectly setting the transition sides somehow, so I'll work on it in another PR. 
 
 I hope you'll find this useful! 
 
 I'll be finalizing this in the coming days, meanwhile if you'll need any changes I'll be happy to discuss, otherwise I'm okay with it not being merged.