### PR TITLE
Update Bevy to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ flagset = "0.4"
 num = "0.4"
 transvoxel-data = "0.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-bevy = { version = "0.10", optional = true }
+bevy = { version = "0.11", optional = true }
 bytemuck = { version = "1.13", optional = true }
 
 [dev-dependencies]
 hamcrest = "0.1"
 ndarray = "0.15"
-bevy = { version = "0.10.1", features = ["dynamic_linking"] }
-bevy_egui = "0.20.2"
+bevy = { version = "0.11", features = ["dynamic_linking"] }
+bevy_egui = "0.21"
 #bevy_screen_diags = "0.4.0"
 noise = "0.8.2"
 rand = "0.8.5"

--- a/examples/non_scalar_voxel_data/main.rs
+++ b/examples/non_scalar_voxel_data/main.rs
@@ -262,14 +262,11 @@ struct ModelMarkerComponent {}
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .add_plugins((FlyCameraPlugin, EguiPlugin))
         //.add_plugin(bevy_screen_diags::ScreenDiagsPlugin::default())
-        .add_startup_system(setup)
-        .add_plugin(FlyCameraPlugin)
-        .add_system(close_on_esc)
-        .add_plugin(EguiPlugin)
+        .add_systems(Startup, setup)
         .init_resource::<MaterialsResource>()
-        .add_system(ui)
-        .add_system(clicks_handler)
+        .add_systems(Update, (close_on_esc, ui, clicks_handler))
         .run();
 }
 

--- a/examples/shared/flycam.rs
+++ b/examples/shared/flycam.rs
@@ -31,7 +31,7 @@ impl Default for FlyCamera {
             key_left: KeyCode::A,
             key_right: KeyCode::D,
             key_up: KeyCode::Space,
-            key_down: KeyCode::LShift,
+            key_down: KeyCode::ShiftLeft,
             enabled: true,
             mouse_motion_enabled: true,
         }
@@ -152,8 +152,7 @@ pub struct FlyCameraPlugin;
 
 impl Plugin for FlyCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(camera_movement_system)
-            .add_system(mouse_motion_system);
+        app.add_systems(Update, (camera_movement_system, mouse_motion_system));
     }
 }
 

--- a/examples/single_block/main.rs
+++ b/examples/single_block/main.rs
@@ -241,18 +241,16 @@ struct ModelMarkerComponent {}
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .add_plugins((FlyCameraPlugin, EguiPlugin))
         //.add_plugin(bevy_screen_diags::ScreenDiagsPlugin::default())
-        .add_startup_system(setup)
-        .add_startup_system(add_initial_model)
-        .add_plugin(FlyCameraPlugin)
-        .add_system(close_on_esc)
-        .add_plugin(EguiPlugin)
+        .add_systems(Startup, (setup, add_initial_model))
         .init_resource::<UiState>()
         .init_resource::<MaterialsResource>()
-        .add_system(ui)
         .add_event::<AppEvent>()
-        .add_system(app_events_handler)
-        .add_system(clicks_handler)
+        .add_systems(
+            Update,
+            (close_on_esc, ui, app_events_handler, clicks_handler),
+        )
         .run();
 }
 
@@ -355,6 +353,7 @@ struct MaterialsResource {
     pub grid_dot: Handle<StandardMaterial>,
 }
 
+#[derive(Event)]
 enum AppEvent {
     LoadModel,
     Quit,

--- a/examples/transition_across_blocks/main.rs
+++ b/examples/transition_across_blocks/main.rs
@@ -256,18 +256,16 @@ struct ModelMarkerComponent {}
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .add_plugins((FlyCameraPlugin, EguiPlugin))
         //.add_plugin(bevy_screen_diags::ScreenDiagsPlugin::default())
-        .add_startup_system(setup)
-        .add_startup_system(add_initial_model)
-        .add_plugin(FlyCameraPlugin)
-        .add_system(close_on_esc)
-        .add_plugin(EguiPlugin)
+        .add_systems(Startup, (setup, add_initial_model))
         .init_resource::<UiState>()
         .init_resource::<MaterialsResource>()
-        .add_system(ui)
         .add_event::<AppEvent>()
-        .add_system(app_events_handler)
-        .add_system(clicks_handler)
+        .add_systems(
+            Update,
+            (close_on_esc, ui, app_events_handler, clicks_handler),
+        )
         .run();
 }
 
@@ -370,6 +368,7 @@ struct MaterialsResource {
     pub grid_dot: Handle<StandardMaterial>,
 }
 
+#[derive(Event)]
 enum AppEvent {
     LoadModel,
     Quit,


### PR DESCRIPTION
Hey. Firstly, thank you for this library!

I just got started with voxels, and wanted to play around. 
Found it easy to just update the Bevy version to `0.11` with the following changes:
- All the Bevy based `examples` updated to the new APIs.
- Fixed all breaking changes. 
- Also the necessary update of `bevy_egui` to `0.21`.

The examples seems to be running fine and all tests are passing.

Hope this helps!